### PR TITLE
flake8 ignore colon whitespace error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,4 +32,4 @@ repos:
     rev: '5.0.4'
     hooks:
     -   id: flake8
-        args: [--max-line-length=88, "--ignore=E741,W503", "--per-file-ignores=*/__init__.py:F401"]
+        args: [--max-line-length=88, "--ignore=E741,W503,E203", "--per-file-ignores=*/__init__.py:F401"]


### PR DESCRIPTION
Ready to merge

**Bug Fix**
The black and flake8 pre-commits had conflicting style guidelines regarding whitespace around colons causing one of them to always fail. This pull request updates the errors which flake8 should ignore in  `pre-commit-config.yaml` so that this conflict no longer happens.

**Related issue, if one exists**
none

**Impacted areas of the software**
`pre-commit-config.yaml`

**Additional supporting information**

**Test results, if applicable**
`============================= test session starts =============================
platform win32 -- Python 3.9.12, pytest-7.1.1, pluggy-1.0.0
rootdir: C:\Users\ztully\Documents\electrolyzer_model\electrolyzer, configfile: 
pyproject.toml, testpaths: tests
plugins: anyio-3.5.0
collected 32 items

tests\test_cell.py ..........                                            [ 31%]
tests\test_electrolyzer.py .                                             [ 34%]
tests\test_stack.py EEF.....E........                                    [ 87%]
tests\test_type_dec.py ....                                              [100%]

=================================== ERRORS ==================================== 
_________________________ ERROR at setup of test_init _________________________ 
file C:\Users\ztully\Documents\electrolyzer_model\electrolyzer\tests\test_stack.py, line 24
  def test_init(mocker):
E       fixture 'mocker' not found
>       available fixtures: anyio_backend, anyio_backend_name, anyio_backend_options, cache, capfd, capfdbinary, caplog, capsys, capsysbinary, doctest_namespace, monkeypatch, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, stack, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory
>       use 'pytest --fixtures [testpath]' for help on them.

C:\Users\ztully\Documents\electrolyzer_model\electrolyzer\tests\test_stack.py:24_________________________ ERROR at setup of test_run __________________________ 
file C:\Users\ztully\Documents\electrolyzer_model\electrolyzer\tests\test_stack.py, line 81
  def test_run(mocker):
E       fixture 'mocker' not found
>       available fixtures: anyio_backend, anyio_backend_name, anyio_backend_options, cache, capfd, capfdbinary, caplog, capsys, capsysbinary, doctest_namespace, monkeypatch, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, stack, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory
>       use 'pytest --fixtures [testpath]' for help on them.

C:\Users\ztully\Documents\electrolyzer_model\electrolyzer\tests\test_stack.py:81__________________ ERROR at setup of test_update_degradation __________________ 
file C:\Users\ztully\Documents\electrolyzer_model\electrolyzer\tests\test_stack.py, line 216
  def test_update_degradation(mocker):
E       fixture 'mocker' not found
>       available fixtures: anyio_backend, anyio_backend_name, anyio_backend_options, cache, capfd, capfdbinary, caplog, capsys, capsysbinary, doctest_namespace, monkeypatch, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, stack, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory
>       use 'pytest --fixtures [testpath]' for help on them.

C:\Users\ztully\Documents\electrolyzer_model\electrolyzer\tests\test_stack.py:216
================================== FAILURES =================================== 
__________________________ test_create_polarization ___________________________ 

stack = Stack(cell_area=1000, max_current=2000, temperature=60, n_cells=100, min_power=46660.87847588875, stack_rating_kW=466....dt=1, time=0, tau=5, stack_state=0, DTSS=[array([[0.81873075]]), array([[0.90634623]]), array([[0.2]]), array([[0.]])])

    def test_create_polarization(stack: Stack):
        """
        Should create a polarization curve based on fit for the specified model 
over a
        range of temperatures.
        """
        fit_params = stack.create_polarization()

        # this is brittle, so for now use a lenient precision check
        expected = [
            -2.28261081e-03,
            -1.50848325e-02,
            7.89259537e-03,
            4.80671306e00,
            9.74923247e-01,
            1.36179580e01,
        ]
>       assert_array_almost_equal(fit_params, expected, decimal=3)
E       AssertionError: 
E       Arrays are not almost equal to 3 decimals
E       
E       Mismatched elements: 1 / 6 (16.7%)
E       Max absolute difference: 0.00520841
E       Max relative difference: 0.00038247
E        x: array([-2.283e-03, -1.508e-02,  7.893e-03,  4.807e+00,  9.747e-01,  
E               1.362e+01])
E        y: array([-2.283e-03, -1.508e-02,  7.893e-03,  4.807e+00,  9.749e-01,  
E               1.362e+01])

tests\test_stack.py:147: AssertionError
=========================== short test summary info ===========================
FAILED tests/test_stack.py::test_create_polarization - AssertionError:
ERROR tests/test_stack.py::test_init
ERROR tests/test_stack.py::test_run
ERROR tests/test_stack.py::test_update_degradation
=================== 1 failed, 28 passed, 3 errors in 3.54s ====================`

<!-- Release checklist:
- Update the version in
    - [ ] README.rst
    - [ ] docs/index.rst
    - [ ] electrolyzer/version
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in the NREL/electrolyzer repository
-->