### PR TITLE
Feature/deg time scale 1

### DIFF
--- a/electrolyzer/stack.py
+++ b/electrolyzer/stack.py
@@ -93,10 +93,10 @@ class Stack(FromDictMixin):
     turn_on_delay: float = field(init=False)
 
     # keep track of when the stack was last turned on
-    turn_on_time: float = field(init=False, default=0)
+    turn_on_time: float = field(init=False)
 
     # keep track of when the stack was last turned off
-    turn_off_time: float = field(init=False, default=-1000)
+    turn_off_time: float = field(init=False)
 
     # wait time for partial startup procedure (set in __attrs_post_init)
     wait_time: float = field(init=False)
@@ -136,6 +136,9 @@ class Stack(FromDictMixin):
             self.turn_on_delay = 0
         else:
             self.turn_on_delay = self.base_turn_on_delay
+
+        self.turn_on_time = 0
+        self.turn_off_time = -self.turn_on_delay
 
         self.wait_time = np.min(
             [

--- a/electrolyzer/stack.py
+++ b/electrolyzer/stack.py
@@ -101,9 +101,6 @@ class Stack(FromDictMixin):
     # wait time for partial startup procedure (set in __attrs_post_init)
     wait_time: float = field(init=False)
 
-    # # [s] simulation time step
-    # dt: float = 1
-
     # [s] total time of simulation
     time: float = field(init=False, default=0)
 
@@ -140,7 +137,12 @@ class Stack(FromDictMixin):
         else:
             self.turn_on_delay = self.base_turn_on_delay
 
-        self.wait_time = self.turn_on_time
+        self.wait_time = np.min(
+            [
+                (self.turn_on_time - self.turn_off_time),
+                self.turn_on_delay,
+            ]
+        )
 
         # [kW] nameplate power rating
         self.stack_rating_kW = self.stack_rating_kW or self.calc_stack_power(

--- a/tests/glue_code/test_run_electrolyzer.py
+++ b/tests/glue_code/test_run_electrolyzer.py
@@ -14,7 +14,6 @@ import electrolyzer.inputs.validation as val
 from electrolyzer import Supervisor
 from electrolyzer.glue_code.run_electrolyzer import run_electrolyzer
 
-
 turbine_rating = 3.4  # MW
 
 # Create cosine test signal

--- a/tests/glue_code/test_run_electrolyzer.py
+++ b/tests/glue_code/test_run_electrolyzer.py
@@ -14,6 +14,7 @@ import electrolyzer.inputs.validation as val
 from electrolyzer import Supervisor
 from electrolyzer.glue_code.run_electrolyzer import run_electrolyzer
 
+
 turbine_rating = 3.4  # MW
 
 # Create cosine test signal
@@ -87,7 +88,7 @@ def test_regression(result):
     _, df = result
 
     # Test total kg H2 produced
-    assert_almost_equal(df["kg_rate"].sum(), 222.87991746974592, decimal=4)
+    assert_almost_equal(df["kg_rate"].sum(), 222.8930364856318, decimal=4)
 
     # Test degradation state of stacks
     degradation = df[[col for col in df if "deg" in col]]

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -66,8 +66,8 @@ def test_init(mocker):
     assert stack.stack_waiting is False
     assert stack.turn_on_delay == 600
     assert stack.turn_on_time == 0
-    assert stack.turn_off_time == -1000
-    assert stack.wait_time == stack.turn_on_time
+    assert stack.turn_off_time < 0
+    assert stack.wait_time > 0
     assert stack.dt == 1.0
     assert stack.time == 0
     assert stack.tau == 5.0
@@ -337,6 +337,7 @@ def test_turn_stack_off(stack: Stack):
     assert stack.cycle_count == 0
 
     stack.stack_on = True
+    stack.time = 800
     stack.turn_stack_off()
     assert stack.turn_off_time == stack.time
     assert stack.stack_on is False


### PR DESCRIPTION
Ready to be merged
Tests expected to pass

**Feature or improvement description**
A few changes to stack degradation calculations so that steady degradation scales appropriately with simulation time step

**Related issue, if one exists**
#20 

**Impacted areas of the software**
`electrolyzer/stack.py` - Changed a few details about how `wait_time` is initialized and calculated.
`tests/test_stack.py` - Updated a few tests to reflect the changes to `wait_time`

**Additional supporting information**
This PR should be thought of as only an intermediate improvement to the multi-timescale degradation calculation. Neither the rates nor methods used to calculate fluctuating and on/off degradation have been changed. With larger time steps, these two components will be underrepresented in the total degradation because fewer on/off and fluctuation "events" will occur. Fluctuation and on/off degradation will still be penalized so the degradation model may be useful but be aware that it will not match degradation calculated with dt = 1 second.


Below are some test signals for a 24 hour period sampled at dt = 1, 60, and 3600 seconds to illustrate the consistency of the steady degradation adjustment.  Note that the signals do not have a large amount of fluctuation and also that number of on/off cycles is counted as the same in all 3 cases.  If there were bigger differences in either of those factors then the total degradation would change more significantly across the three time step cases. 

![dt_input_grid_ZOH_delay_yes_change](https://user-images.githubusercontent.com/107644545/224834172-9582a2e5-d100-41bd-831f-f7957e3a3a85.png)


<!-- Release checklist:
- Update the version in
    - [ ] README.rst
    - [ ] docs/index.rst
    - [ ] electrolyzer/version
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in the NREL/electrolyzer repository
-->