### PR TITLE
Update LCOH for optimization runs

### DIFF
--- a/electrolyzer/glue_code/run_lcoh.py
+++ b/electrolyzer/glue_code/run_lcoh.py
@@ -3,132 +3,25 @@ This module is responsible for running electrolyzer models based on YAML configu
 files.
 """
 
-import numpy as np
 import pandas as pd
 
 import electrolyzer.inputs.validation as val
 from electrolyzer import LCOH  # ESG
-from electrolyzer import Supervisor
 
-from .optimization import calc_rated_system
-
-
-def _run_electrolyzer_full(modeling_options, power_signal):
-    # Initialize system
-    elec_sys = Supervisor.from_dict(modeling_options["electrolyzer"])
-    # initialize cost system
-    cost_sys = LCOH.from_dict(modeling_options["electrolyzer"]["costs"])
-
-    # Define output variables
-    kg_rate = np.zeros((elec_sys.n_stacks, len(power_signal)))
-    degradation = np.zeros((elec_sys.n_stacks, len(power_signal)))
-    curtailment = np.zeros((len(power_signal)))
-    tot_kg = np.zeros((len(power_signal)))
-    cycles = np.zeros((elec_sys.n_stacks, len(power_signal)))
-    uptime = np.zeros((elec_sys.n_stacks, len(power_signal)))
-    current_density = np.zeros((elec_sys.n_stacks, len(power_signal)))
-    p_in = []
-
-    # Run electrolyzer simulation
-    for i in range(len(power_signal)):
-        # TODO: replace with proper logging
-        # if (i % 1000) == 0:
-        #     print('Progress', i)
-        # print(i)
-        loop_H2, loop_h2_mfr, loop_power_left, curtailed = elec_sys.run_control(
-            power_signal[i]
-        )
-        p_in.append(power_signal[i] / elec_sys.n_stacks / 1000)
-
-        tot_kg[i] = loop_H2
-        curtailment[i] = curtailed / 1000000
-        for j in range(elec_sys.n_stacks):
-            stack = elec_sys.stacks[j]
-            kg_rate[j, i] = loop_h2_mfr[j]
-            degradation[j, i] = stack.V_degradation
-            cycles[j, i] = stack.cycle_count
-            uptime[j, i] = stack.uptime
-            current_density[j, i] = stack.I / stack.cell.cell_area
-
-    # Collect results into a DataFrame
-    results_df = pd.DataFrame(
-        {
-            "power_signal": power_signal,
-            "curtailment": curtailment,
-            "kg_rate": tot_kg,
-        }
-    )
-
-    # for efficiency reasons, create a df for each stack, then concat all at the end
-    stack_dfs = []
-
-    for i, stack in enumerate(elec_sys.stacks):
-        id = i + 1
-        stack_df = pd.DataFrame(
-            {
-                f"stack_{id}_deg": degradation[i, :],
-                f"stack_{id}_fatigue": stack.fatigue_history,
-                f"stack_{id}_cycles": cycles[i, :],
-                f"stack_{id}_uptime": uptime[i, :],
-                f"stack_{id}_kg_rate": kg_rate[i, :],
-                f"stack_{id}_curr_density": current_density[i, :],
-            }
-        )
-        stack_dfs.append(stack_df)
-
-    results_df = pd.concat([results_df, *stack_dfs], axis=1)
-    # return elec_sys & results & cost sys to use in LCOH
-    return elec_sys, results_df, cost_sys
+from .run_electrolyzer import _run_electrolyzer_full
 
 
-def _run_electrolyzer_opt(modeling_options, power_signal):
-    # Tune to a desired system rating
-    options = calc_rated_system(modeling_options)
-
-    # Initialize system
-    elec_sys = Supervisor.from_dict(options["electrolyzer"])
-
-    # Define output variables
-    tot_kg = 0.0
-    max_curr_density = 0.0
-
-    # Run electrolyzer simulation
-    for i in range(len(power_signal)):
-        # TODO: replace with proper logging
-        # if (i % 1000) == 0:
-        #     print('Progress', i)
-        # print(i)
-        loop_H2, loop_h2_mfr, loop_power_left, curtailed = elec_sys.run_control(
-            power_signal[i]
-        )
-
-        tot_kg += loop_H2
-        new_curr = max([s.I / s.cell.cell_area for s in elec_sys.stacks])
-        max_curr_density = max(max_curr_density, new_curr)
-
-    return tot_kg, max_curr_density
-
-
-def _run_lcoh_full(elec_sys, elec_df, cost_sys, lcoe):
-    # Called after simulation
-    # Below is used as a bit of a work-around for some bugs I was having
-    # basically just initialize
-    cost_sys.get_simulation_info(elec_sys, elec_df, lcoe)
-    # below is the main run function
+def _run_lcoh_full(cost_sys):
     lcoh = cost_sys.run_lcoh()
 
     # all code below this is used to get specific cost information
     # and lcoh breakdowns - feel free to comment out if you just
     # the lcoh
-    lcoh_df_tots = pd.concat(
-        [
-            pd.Series(cost_sys.LCOH_summary["Totals [$]"], name="Life Totals [$]"),
-            pd.Series(
-                cost_sys.LCOH_summary["Totals [$/kg-H2]"], name="Life Totals [$/kg-H2]"
-            ),
-        ],
-        axis=1,
-    )
+    data = {
+        "Life Totals [$]": cost_sys.LCOH_summary["Totals [$]"],
+        "Life Totals [$/kg-H2]": cost_sys.LCOH_summary["Totals [$/kg-H2]"],
+    }
+    lcoh_df_tots = pd.DataFrame(data)
 
     stack_rep_keys = [
         "Stack Replacement Cost [$/kW]",
@@ -160,21 +53,16 @@ def _run_lcoh_full(elec_sys, elec_df, cost_sys, lcoe):
     }
 
     cost_sys.LCOH_summary["Yearly"]
-    stackrep_yrly = pd.concat(
-        [
-            pd.Series(
-                cost_sys.stack_replacement_summary["Annual Stack Replacement Cost [$]"],
-                name="SR-Cost [$]",
-            ),
-            pd.Series(
-                cost_sys.stack_replacement_schedule[
-                    "Annual Number of Stacks to Replace"
-                ],
-                name="num SR/year",
-            ),
+    data = {
+        "SR-Cost [$]": cost_sys.stack_replacement_summary[
+            "Annual Stack Replacement Cost [$]"
         ],
-        axis=1,
-    )
+        "num SR/year": cost_sys.stack_replacement_schedule[
+            "Annual Number of Stacks to Replace"
+        ],
+    }
+    stackrep_yrly = pd.DataFrame(data)
+
     # cost_sys.StackReplacement_schedule['Hrs until Replacement']
     # cost_sys.StackReplacement_schedule['Stacks Replaced']
     lcoh_dict = {
@@ -212,13 +100,7 @@ def run_lcoh(input_modeling, power_signal, lcoe):
         'lcoh' LCOh in $/kg-H2
     """
     err_msg = "Model input must be a str or dict object"
-    assert isinstance(
-        input_modeling,
-        (
-            str,
-            dict,
-        ),
-    ), err_msg
+    assert isinstance(input_modeling, (str, dict)), err_msg
 
     if isinstance(input_modeling, str):
         # Parse/validate yaml configuration
@@ -230,11 +112,26 @@ def run_lcoh(input_modeling, power_signal, lcoe):
     #     return _run_electrolyzer_opt(modeling_options, power_signal)
     # step 0: initialize electorolyzer and cost systems.
     # step 1: run the electrolyzer!
-    elec_sys, results_df, cost_sys = _run_electrolyzer_full(
-        modeling_options, power_signal
+    elec_sys, elec_df = _run_electrolyzer_full(modeling_options, power_signal)
+    lcoh_options = modeling_options["electrolyzer"]["costs"]
+    lcoh_options.update(
+        {
+            "dt": elec_sys.dt,
+            "sim_length_hrs": len(elec_df["power_signal"]) * elec_sys.dt / 3600,
+            "plant_rating_kW": elec_sys.n_stacks * elec_sys.stack_rating_kW,
+            "n_stacks": elec_sys.n_stacks,
+            "stack_rating_kW": elec_sys.stack_rating_kW,
+            "deg_state": elec_sys.deg_state,
+            "power_kW_avail": elec_df["power_signal"].values / 1000,
+            "power_kW_curtailed": elec_df["curtailment"].values / 1000,
+            "kg_produced": elec_df["kg_rate"].values,
+            "electrical_feedstock_cost": lcoe,  # [$/kWh]
+        }
     )
 
+    cost_sys = LCOH.from_dict(lcoh_options)
+
     # step 2: run lcoh calculations
-    # TODO: separate electrolyzer simulation & LCOH simulation
-    lcoh_dict, lcoh = _run_lcoh_full(elec_sys, results_df, cost_sys, lcoe)
+    lcoh_dict, lcoh = _run_lcoh_full(cost_sys)
+
     return lcoh_dict, lcoh

--- a/electrolyzer/glue_code/run_lcoh.py
+++ b/electrolyzer/glue_code/run_lcoh.py
@@ -134,7 +134,7 @@ def _run_lcoh_full(elec_sys, elec_df, cost_sys, lcoe):
         "Stack Replacement Cost [$/kW]",
         "Stack Replacement Cost [$/stack]",
     ]
-    sr_srs = pd.Series(cost_sys.StackReplacement_summary, name="Stack Replacement")[
+    sr_srs = pd.Series(cost_sys.stack_replacement_summary, name="Stack Replacement")[
         stack_rep_keys
     ]
 
@@ -143,18 +143,18 @@ def _run_lcoh_full(elec_sys, elec_df, cost_sys, lcoe):
         "Annual H20 Cost [$]",
         "Total Feedstock Cost [$]",
     ]
-    fds_srs = pd.Series(cost_sys.Feedstock_summary, name="Feedstock")[feedstock_keys]
+    fds_srs = pd.Series(cost_sys.feedstock_summary, name="Feedstock")[feedstock_keys]
     cpx_srs = pd.concat(
         [
-            pd.Series(cost_sys.CapEx_summary["BOP"], name="BOP"),
-            pd.Series(cost_sys.CapEx_summary["PEM"], name="PEM"),
+            pd.Series(cost_sys.capex_summary["BOP"], name="BOP"),
+            pd.Series(cost_sys.capex_summary["PEM"], name="PEM"),
         ],
         axis=1,
     )
 
     raw_dict = {
         "CapEx": cpx_srs,
-        "OpEx": pd.Series(cost_sys.OpEx_summary, name="OpEx"),
+        "OpEx": pd.Series(cost_sys.opex_summary, name="OpEx"),
         "Feedstock": fds_srs,
         "Stack Replacement": sr_srs,
     }
@@ -163,11 +163,11 @@ def _run_lcoh_full(elec_sys, elec_df, cost_sys, lcoe):
     stackrep_yrly = pd.concat(
         [
             pd.Series(
-                cost_sys.StackReplacement_summary["Annual Stack Replacement Cost [$]"],
+                cost_sys.stack_replacement_summary["Annual Stack Replacement Cost [$]"],
                 name="SR-Cost [$]",
             ),
             pd.Series(
-                cost_sys.StackReplacement_schedule[
+                cost_sys.stack_replacement_schedule[
                     "Annual Number of Stacks to Replace"
                 ],
                 name="num SR/year",

--- a/electrolyzer/inputs/modeling_schema.yaml
+++ b/electrolyzer/inputs/modeling_schema.yaml
@@ -95,3 +95,94 @@ properties:
                 type: object
                 default: {}
                 description: Set cost modeling properties for electrolyzers
+                properties:
+                    plant_params:
+                        type: object
+                        description: Parameters related to the plant.
+                        properties:
+                            plant_life:
+                                type: integer
+                                description: Plant life in years.
+                                minimum: 1
+                            pem_location:
+                                type: string
+                                description: Location of the PEM electrolyzer (onshore, offshore, or in-turbine).
+                                enum: [onshore, offshore, in-turbine]
+                                default: onshore
+                            grid_connected:
+                                type: boolean
+                                description: Whether the plant is connected to the grid or not.
+                    feedstock:
+                        type: object
+                        description: Parameters related to the feedstock.
+                        properties:
+                            water_feedstock_cost:
+                                type: number
+                                description: Cost of water feedstock per kg of water.
+                                minimum: 0
+                            water_per_kgH2:
+                                type: number
+                                description: Amount of water required per kg of hydrogen produced (placeholder).
+                                minimum: 0
+                    opex:
+                        type: object
+                        description: Operational expenditure parameters.
+                        properties:
+                            var_OM:
+                                type: number
+                                description: Variable operation and maintenance cost per kW.
+                                minimum: 0
+                            fixed_OM:
+                                type: number
+                                description: Fixed operation and maintenance cost per kW-year.
+                                minimum: 0
+                    stack_replacement:
+                        type: object
+                        description: Parameters related to stack replacement.
+                        properties:
+                            d_eol:
+                                type: number
+                                description: End of life cell voltage value.
+                                minimum: 0
+                            stack_replacement_percent:
+                                type: number
+                                description: Stack replacement cost as a percentage of CapEx.
+                                minimum: 0
+                                maximum: 1
+                    capex:
+                        type: object
+                        description: Capital expenditure parameters.
+                        properties:
+                            capex_learning_rate:
+                                type: number
+                                description: Capital expenditure learning rate.
+                                minimum: 0
+                            ref_cost_bop:
+                                type: number
+                                description: Reference cost for balance of plant per kW.
+                                minimum: 0
+                            ref_size_bop:
+                                type: number
+                                description: Reference size for balance of plant in kW.
+                                minimum: 0
+                            ref_cost_pem:
+                                type: number
+                                description: Reference cost for PEM per kW.
+                                minimum: 0
+                            ref_size_pem:
+                                type: number
+                                description: Reference size for PEM in kW.
+                                minimum: 0
+                    finances:
+                        type: object
+                        description: Financial parameters.
+                        properties:
+                            discount_rate:
+                                type: number
+                                description: Discount rate for financial calculations.
+                                minimum: 0
+                            install_factor:
+                                type: number
+                                description: Installation factor as a percentage.
+                                minimum: 0
+                                maximum: 1

--- a/examples/example_04_lcoh/cost_modeling_options.yaml
+++ b/examples/example_04_lcoh/cost_modeling_options.yaml
@@ -12,6 +12,7 @@ electrolyzer:
         stack_rating_kW: 500
     control:
         n_stacks: 7
+        system_rating_MW: 3.5 # required for optimize=True run
         control_type: BaselineDeg # default
     costs:
         plant_params:

--- a/tests/glue_code/test_run_lcoh.py
+++ b/tests/glue_code/test_run_lcoh.py
@@ -50,5 +50,4 @@ def test_run_lcoh():
         atol=1e-4,
     )
 
-    print(calc_result[1], RESULT[1])
     assert np.isclose(calc_result[1], RESULT[1])

--- a/tests/glue_code/test_run_lcoh.py
+++ b/tests/glue_code/test_run_lcoh.py
@@ -1,8 +1,9 @@
-import numpy as np
 import os
+from pathlib import Path
+
+import numpy as np
 import pandas as pd
 from pandas.testing import assert_frame_equal
-from pathlib import Path
 
 from electrolyzer import run_lcoh
 
@@ -10,12 +11,17 @@ from electrolyzer import run_lcoh
 lcoh_breakdown = pd.DataFrame(
     {
         "Life Totals [$]": [5.388657e06, 1.079412e06, 1.197895e07, 1.283473e06],
-        "Life Totals [$/kg-H2]": [1.359484, 0.272321, 3.022124, 0.323803],
+        "Life Totals [$/kg-H2]": [
+            1.3594040320184078,
+            0.2723048458021954,
+            3.021946178528131,
+            0.32378362036676683,
+        ],
     },
     index=["CapEx", "OM", "Feedstock", "Stack Rep"],
 )
 
-RESULT = (lcoh_breakdown, 4.9777312843759915)
+RESULT = (lcoh_breakdown, 4.977438676715502)
 ROOT = Path(__file__).parent.parent.parent
 
 
@@ -43,4 +49,6 @@ def test_run_lcoh():
         check_exact=False,
         atol=1e-4,
     )
+
+    print(calc_result[1], RESULT[1])
     assert np.isclose(calc_result[1], RESULT[1])


### PR DESCRIPTION
resolves #47 
resolves #45 

## Changes

### Python clean up

Primarily small changes to naming conventions and `DataFrame` usage.

### Decoupling `LCOH` from `Supervisor`

This change makes it so that `LCOH` does not depend on the `Supervisor` instance internally. This makes our run code simpler (including for optimization runs) and opens the future opportunity for users to run LCOH with results from other electrolyzer simulations based on a structured interface. The tradeoff is that it requires a number of fields to be passed to `LCOH` that were previously contained in the `Supervisor` instance. We could put all of these in a single field via a dict, but for now they're simply attributes.

### Add schema definitions for LCOH

This is based on the example and test from #26. 

### Allowing LCOH with optimizations

We're now ready to integrate with WISDEM!

## Tests

The existing LCOH test immediately failed on my machine before making any changes (see https://github.com/NREL/electrolyzer/pull/48/commits/f4bf48faf09924a2f33a168b9a22351214234023). I could use some confirmation on this.

I also added a test for the new `optimize=True` functionality.

Unit tests and documentation for `LCOH` coming with #44 
