### PR TITLE
Bump isort version for pre-commit bugfix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
         - id: isort
           name: isort


### PR DESCRIPTION
This fixes a bug when first installing pre-commit hooks, related to this issue in the [isort](https://github.com/PyCQA/isort/commit/0d219a6e0b49b7f84ef0702b2387d5e14299bb8e) package. v5.12.0 fixes the issue.