### PR TITLE
Updating dryer loss and membrane thickness

### DIFF
--- a/electrolyzer/cell.py
+++ b/electrolyzer/cell.py
@@ -141,7 +141,7 @@ class Cell(FromDictMixin):
         # pulled from https://www.sciencedirect.com/science/article/pii/S0360319917309278?via%3Dihub # noqa
         # TODO: pulled from empirical data, is there a better eq?
         lambda_nafion = ((-2.89556 + (0.016 * T_K)) + 1.625) / 0.1875
-        t_nafion = 0.03  # (cm) TODO: confirm actual thickness?
+        t_nafion = 0.02  # (cm) confirmed that membrane thickness is <0.02.
 
         # TODO: confirm with Nel, is there a better eq?
         sigma_nafion = ((0.005139 * lambda_nafion) - 0.00326) * np.exp(

--- a/electrolyzer/cell.py
+++ b/electrolyzer/cell.py
@@ -231,7 +231,7 @@ class Cell(FromDictMixin):
 
         return eta_F
 
-    def calc_mass_flow_rate(self, Idc, dryer_loss=6.5):
+    def calc_mass_flow_rate(self, Idc, dryer_loss=0.2):
         """
         Idc [A]: stack current
         dryer_loss [%]: loss of drying H2

--- a/examples/example_01_polarization/example_run.py
+++ b/examples/example_01_polarization/example_run.py
@@ -11,12 +11,14 @@ n_cells = 100  # number of cells in stack
 cell_area = 1000  # cell area, cm^2
 temperature = 60  # temperature
 max_current = 2000
+dt = 1  # second
 
 stack_dict = {
     "n_cells": n_cells,
     "cell_area": cell_area,
     "temperature": temperature,
     "max_current": max_current,
+    "dt": dt,
 }
 
 elec = Stack.from_dict(stack_dict)
@@ -25,6 +27,7 @@ cur = np.linspace(0, 2500, 100)
 p_fit = elec.calc_stack_power(
     electrolyzer_model((elec.calc_stack_power(cur), temperature), *elec.fit_params)
 )
+
 p_actual = elec.calc_stack_power(cur)
 voltage = elec.cell.calc_cell_voltage(cur, temperature)
 fit_error = p_actual - p_fit

--- a/tests/glue_code/test_run_electrolyzer.py
+++ b/tests/glue_code/test_run_electrolyzer.py
@@ -135,7 +135,7 @@ def test_regression(result):
     _, df = result
 
     # Test total kg H2 produced
-    assert_almost_equal(df["kg_rate"].sum(), 219.0721736179, decimal=1)
+    assert_almost_equal(df["kg_rate"].sum(), 233.833186, decimal=1)
 
     # Test degradation state of stacks
     degradation = df[[col for col in df if "deg" in col]]

--- a/tests/glue_code/test_run_electrolyzer.py
+++ b/tests/glue_code/test_run_electrolyzer.py
@@ -135,7 +135,7 @@ def test_regression(result):
     _, df = result
 
     # Test total kg H2 produced
-    assert_almost_equal(df["kg_rate"].sum(), 233.833186, decimal=1)
+    assert_almost_equal(df["kg_rate"].sum(), 243.44252981356382, decimal=1)
 
     # Test degradation state of stacks
     degradation = df[[col for col in df if "deg" in col]]

--- a/tests/glue_code/test_run_lcoh.py
+++ b/tests/glue_code/test_run_lcoh.py
@@ -11,18 +11,18 @@ from electrolyzer import run_lcoh, run_electrolyzer
 
 lcoh_breakdown = pd.DataFrame(
     {
-        "Life Totals [$]": [5.388657e06, 1.079412e06, 1.1980506e07, 1.292115e06],
+        "Life Totals [$]": [5.388657e06, 1.079412e06, 1.1981873e07, 1.225039e06],
         "Life Totals [$/kg-H2]": [
-            1.3594040320184078,
+            1.2446538284076922,
             0.2723048458021954,
-            2.880935150646775,
+            2.7675325314357866,
             0.32378362036676683,
         ],
     },
     index=["CapEx", "OM", "Feedstock", "Stack Rep"],
 )
 
-RESULT = (lcoh_breakdown, 4.747015793929487)
+RESULT = (lcoh_breakdown, 4.544460891727074)
 ROOT = Path(__file__).parent.parent.parent
 
 
@@ -78,4 +78,4 @@ def test_run_lcoh_opt():
     # results from regular optimize run should match
     assert_array_almost_equal(h2_result, lcoh_result[:2])
 
-    assert np.isclose(lcoh_result[2], 4.6942216397622)
+    assert np.isclose(lcoh_result[2], 4.454555848862855)

--- a/tests/glue_code/test_run_lcoh.py
+++ b/tests/glue_code/test_run_lcoh.py
@@ -11,18 +11,18 @@ from electrolyzer import run_lcoh, run_electrolyzer
 
 lcoh_breakdown = pd.DataFrame(
     {
-        "Life Totals [$]": [5.388657e06, 1.079412e06, 1.1978406e07, 1.292115e06],
+        "Life Totals [$]": [5.388657e06, 1.079412e06, 1.1980506e07, 1.292115e06],
         "Life Totals [$/kg-H2]": [
             1.3594040320184078,
             0.2723048458021954,
-            3.021946178528131,
+            2.880935150646775,
             0.32378362036676683,
         ],
     },
     index=["CapEx", "OM", "Feedstock", "Stack Rep"],
 )
 
-RESULT = (lcoh_breakdown, 5.066329157584628)
+RESULT = (lcoh_breakdown, 4.747015793929487)
 ROOT = Path(__file__).parent.parent.parent
 
 
@@ -78,4 +78,4 @@ def test_run_lcoh_opt():
     # results from regular optimize run should match
     assert_array_almost_equal(h2_result, lcoh_result[:2])
 
-    assert np.isclose(lcoh_result[2], 5.0099777502488525)
+    assert np.isclose(lcoh_result[2], 4.6942216397622)

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -147,12 +147,12 @@ def test_create_polarization(stack: Stack):
     #    1.36179580e01,
     # ]
     expected = [
-        -2.14872235e-03,
-        -1.62346659e-02,
-        7.31103190e-03,
-        4.71239486e00,
-        1.06583019e00,
-        1.11700091e01,
+        -1.99627103e-03,
+        -1.27808907e-02,
+        4.76371760e-03,
+        4.98846103e00,
+        7.96586249e-01,
+        1.11445867e01,
     ]
 
     assert_array_almost_equal(fit_params, expected, decimal=2)
@@ -386,7 +386,7 @@ def test_calc_electrolysis_efficiency(stack: Stack):
     assert len(eta_values) == 3
 
     # efficiency should decrease as we approach max current due to overpotentials
-    assert eta_values[0] > 79  # highest efficiency around 80% capacity
+    assert eta_values[0] > 75  # highest efficiency around 80% capacity
     H2_mfr2 = stack.cell.calc_mass_flow_rate(stack.max_current) * stack.n_cells
     eta_values2 = stack.calc_electrolysis_efficiency(
         stack.stack_rating_kW, H2_mfr2 * 3600

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -386,7 +386,7 @@ def test_calc_electrolysis_efficiency(stack: Stack):
     assert len(eta_values) == 3
 
     # efficiency should decrease as we approach max current due to overpotentials
-    assert eta_values[0] > 80  # highest efficiency around 80% capacity
+    assert eta_values[0] > 79  # highest efficiency around 80% capacity
     H2_mfr2 = stack.cell.calc_mass_flow_rate(stack.max_current) * stack.n_cells
     eta_values2 = stack.calc_electrolysis_efficiency(
         stack.stack_rating_kW, H2_mfr2 * 3600


### PR DESCRIPTION
Solves #70 and #71. 

After discussions with manufacturers, some values were identified as being too large and robbing our model of performance. 

- Dryer loss is reduced from 6.5% to 0.2% for large (>1MW) electrolyzer stacks. The drying system for an electrolyzer of this size is quite efficient. 

- Membrane thickness is reduced from 0.03cm to 0.02cm because today's commercially available membranes are thinner. 

Overall, these updates impact `cell.py` and `stack.py` by calculating a new mass flow-rate and electrolysis efficiency. 

After running the tests, the new values resulted in increased hydrogen production, increased efficiency (kg/kWh), and a lower LCOH. 
